### PR TITLE
Fixed the compatibility problem of serve() in Node 18

### DIFF
--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -98,15 +98,19 @@ export function serve(
 function tryListen(app: Express, port: number, callback: () => void) {
     app.listen(port, () => {
         console.log('Server available at:')
-        const filter = parseInt(process.versions.node.split('.')[0]) >= 18 ?
-            ({ family }) => family === 4 : ({ family }) => family === 'IPv4';
         console.log(
             (
                 Object.values(
                     networkInterfaces()
                 ).flat() as NetworkInterfaceInfo[]
             )
-                .filter(filter)
+                .filter(
+                    ({ family }) =>
+                        family ===
+                        (parseInt(process.versions.node.split('.')[0]) >= 18
+                            ? 4
+                            : 'IPv4')
+                )
                 .map(({ address }) => `http://${address}:${port}`)
                 .join('\n')
         )

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -98,13 +98,15 @@ export function serve(
 function tryListen(app: Express, port: number, callback: () => void) {
     app.listen(port, () => {
         console.log('Server available at:')
+        const filter = parseInt(process.versions.node.split('.')[0]) >= 18 ?
+            ({ family }) => family === 4 : ({ family }) => family === 'IPv4';
         console.log(
             (
                 Object.values(
                     networkInterfaces()
                 ).flat() as NetworkInterfaceInfo[]
             )
-                .filter(({ family }) => family === 'IPv4')
+                .filter(filter)
                 .map(({ address }) => `http://${address}:${port}`)
                 .join('\n')
         )


### PR DESCRIPTION
Becasue of [this issue](https://github.com/nodejs/node/issues/42787), for Node version v18.0.0 or later, the `family` property in each item of `os.networkInterfaces()` becomes an integer `4` or `6` instead of a string `"IPv4"` or `"IPv6"`. This pull request added a judge according to the version of Node.js.